### PR TITLE
Xperia M2 - Add compatibility for rest of family

### DIFF
--- a/jni/offsets.c
+++ b/jni/offsets.c
@@ -249,8 +249,24 @@ struct offsets offsets[] = {
 	{ "SO-02G", "Linux version 3.4.0-perf-gf6a03f1 (BuildUser@BuildHost) (gcc version 4.8 (GCC) ) #1 SMP PREEMPT Wed Aug 5 12:06:34 2015",
 	  { (void*)FSYNC_OFFSET(0xc10e9470) },
 	  (void*)0xc10de07c, (void*)0xc10ddf6c, (void*)0xc0f56dc4, (void*)0xc10dc518 },
-	//M2 18.6.A.0.182
+	//M2_EULTE 18.6.A.0.182
 	{ "D2303", "Linux version 3.4.0-gc82e70f (BuildUser@BuildHost) (gcc version 4.8 (GCC) ) #1 SMP PREEMPT Mon Aug 10 21:54:32 2015",
+	  { (void*)FSYNC_OFFSET(0xc0feaf68) },
+	  (void*)0xc0fe1fbc, (void*)0xc0fe1eac, (void*)0xc0e4aea4, (void*)0xc0fe0458 },
+	//M2_AMERICASLTE 18.6.A.0.182
+	{ "D2306", "Linux version 3.4.0-gc82e70f (BuildUser@BuildHost) (gcc version 4.8 (GCC) ) #1 SMP PREEMPT Mon Aug 10 21:54:32 2015",
+	  { (void*)FSYNC_OFFSET(0xc0feaf68) },
+	  (void*)0xc0fe1fbc, (void*)0xc0fe1eac, (void*)0xc0e4aea4, (void*)0xc0fe0458 },
+	//M2_DSDS 18.6.A.0.182
+	{ "D2302", "Linux version 3.4.0-gc82e70f (BuildUser@BuildHost) (gcc version 4.8 (GCC) ) #1 SMP PREEMPT Mon Aug 10 21:54:32 2015",
+	  { (void*)FSYNC_OFFSET(0xc0feaf68) },
+	  (void*)0xc0fe1fbc, (void*)0xc0fe1eac, (void*)0xc0e4aea4, (void*)0xc0fe0458 },
+	//M2Aqua_EULTE 18.6.A.0.182
+	{ "D2403", "Linux version 3.4.0-gc82e70f (BuildUser@BuildHost) (gcc version 4.8 (GCC) ) #1 SMP PREEMPT Mon Aug 10 21:54:32 2015",
+	  { (void*)FSYNC_OFFSET(0xc0feaf68) },
+	  (void*)0xc0fe1fbc, (void*)0xc0fe1eac, (void*)0xc0e4aea4, (void*)0xc0fe0458 },
+	//M2Aqua_AMERICASLTE 18.6.A.0.182
+	{ "D2406", "Linux version 3.4.0-gc82e70f (BuildUser@BuildHost) (gcc version 4.8 (GCC) ) #1 SMP PREEMPT Mon Aug 10 21:54:32 2015",
 	  { (void*)FSYNC_OFFSET(0xc0feaf68) },
 	  (void*)0xc0fe1fbc, (void*)0xc0fe1eac, (void*)0xc0e4aea4, (void*)0xc0fe0458 },
 	//M2_SS 18.6.A.0.182


### PR DESCRIPTION
Add support for the rest of the Xperia M2 family devices.
Note: M2_EULTE (D2303), M2_AMERICASLTE (D2306), M2_DSDS (D2302), M2Aqua_EULTE (D2403), M2Aqua_AMERICASLTE (D2406) use the same kernel offsets, whereas M2_SS (D2305) has decremented (-00000100) offsets values, even though the kernel fingerprint matches in all of them.
